### PR TITLE
Overwinter Block Decode Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "async": "^2.6.1",
         "base58-native": "^0.1.4",
         "bignum": "^0.13.0",
-        "bitcoinjs-lib-zcash": "^3.4.2",
+        "bitcoinjs-lib-zcash": "git+https://github.com/karel-3d/bitcoinjs-lib#ceac78a4aa83ee502b2a1c2b1a45a83050f3141c",
         "equihashverify": "git+https://github.com/z-nomp/equihashverify.git",
         "merkle-bitcoin": "^1.0.2",
         "promise": "^8.0.1"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "async": "^2.6.1",
         "base58-native": "^0.1.4",
         "bignum": "^0.13.0",
-        "bitcoinjs-lib-zcash": "git+https://github.com/karel-3d/bitcoinjs-lib#ceac78a4aa83ee502b2a1c2b1a45a83050f3141c",
+        "bitcoinjs-lib-zcash": "git+https://github.com/z-nomp/bitcoinjs-lib",
         "equihashverify": "git+https://github.com/z-nomp/equihashverify.git",
         "merkle-bitcoin": "^1.0.2",
         "promise": "^8.0.1"


### PR DESCRIPTION
the direct zcash upstream broke hellcatz overwinter bitcoinlib-js-zcash patch for non-upstream zcash forks.  This request is to change the bitcoinjs-lib-zcash dependency to the hellcatz commit. This needs done until @sennevb's pull request is approved over there.
