### PR TITLE
Swap out bitcoinjs-lib for a version we maintain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
             "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
             "requires": {
-                "co": "^4.6.0",
-                "json-stable-stringify": "^1.0.1"
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
             }
         },
         "ansi-regex": {
@@ -57,7 +57,7 @@
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
             "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
             "requires": {
-                "lodash": "^4.17.10"
+                "lodash": "4.17.10"
             }
         },
         "asynckit": {
@@ -85,7 +85,7 @@
             "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
             "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "base58-native": {
@@ -93,7 +93,7 @@
             "resolved": "https://registry.npmjs.org/base58-native/-/base58-native-0.1.4.tgz",
             "integrity": "sha1-u5I0qN8mYtBLC3Fa7uH4mxX+8TQ=",
             "requires": {
-                "bignum": ">=0.6.1"
+                "bignum": "0.13.0"
             }
         },
         "bcrypt-pbkdf": {
@@ -102,7 +102,7 @@
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "optional": true,
             "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
             }
         },
         "bech32": {
@@ -146,7 +146,7 @@
             "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
             "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "bitcoin-ops": {
@@ -159,38 +159,37 @@
             "resolved": "https://registry.npmjs.org/bitcoin-script/-/bitcoin-script-0.1.1.tgz",
             "integrity": "sha1-UsUE3dweOxMXp7ZWeoiYGz7zkpw=",
             "requires": {
-                "big-integer": "^1.3.19",
-                "bigi": "^1.2.1",
-                "coinkey": "^0.1.0",
-                "ecdsa": "^0.6.0",
-                "js-beautify": "^1.5.4",
-                "ripemd160": "^0.2.0",
-                "secure-random": "^1.1.1",
-                "sha1": "^1.1.0",
-                "sha256": "^0.1.1"
+                "big-integer": "1.6.32",
+                "bigi": "1.4.2",
+                "coinkey": "0.1.0",
+                "ecdsa": "0.6.0",
+                "js-beautify": "1.7.5",
+                "ripemd160": "0.2.1",
+                "secure-random": "1.1.1",
+                "sha1": "1.1.1",
+                "sha256": "0.1.1"
             }
         },
         "bitcoinjs-lib-zcash": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/bitcoinjs-lib-zcash/-/bitcoinjs-lib-zcash-3.4.2.tgz",
-            "integrity": "sha512-+ebdv6Eg57jW1+zI2wuoYmjW+VBVMTk/D/ADfLEkXiJZSiTorVanMgDZS0fD8g5LRQNbt52rznR2UTlS4Gbi8A==",
+            "version": "git+https://github.com/z-nomp/bitcoinjs-lib.git#fc523458e9ace8465e8d95ce621b360c44c8f6db",
             "requires": {
-                "bech32": "^1.1.2",
-                "bigi": "^1.4.0",
-                "bip66": "^1.1.0",
-                "bitcoin-ops": "^1.3.0",
-                "bitcoin-script": "^0.1.1",
-                "bs58check": "^2.0.0",
-                "create-hash": "^1.1.0",
-                "create-hmac": "^1.1.3",
-                "ecurve": "^1.0.0",
-                "merkle-lib": "^2.0.10",
-                "pushdata-bitcoin": "^1.0.1",
-                "randombytes": "^2.0.1",
-                "safe-buffer": "^5.0.1",
-                "typeforce": "^1.11.3",
-                "varuint-bitcoin": "^1.0.4",
-                "wif": "^2.0.1"
+                "bech32": "1.1.3",
+                "bigi": "1.4.2",
+                "bip66": "1.1.5",
+                "bitcoin-ops": "1.4.1",
+                "bitcoin-script": "0.1.1",
+                "blake2b": "2.1.2",
+                "bs58check": "2.1.2",
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "ecurve": "1.0.6",
+                "merkle-lib": "2.0.10",
+                "pushdata-bitcoin": "1.0.1",
+                "randombytes": "2.0.6",
+                "safe-buffer": "5.1.2",
+                "typeforce": "1.12.0",
+                "varuint-bitcoin": "1.1.0",
+                "wif": "2.0.6"
             }
         },
         "bl": {
@@ -202,12 +201,29 @@
                 "safe-buffer": "5.1.2"
             }
         },
+        "blake2b": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.2.tgz",
+            "integrity": "sha1-aIDt3KNc/t6SxPsnJCITNPmJFFo=",
+            "requires": {
+                "blake2b-wasm": "1.1.7",
+                "nanoassert": "1.1.0"
+            }
+        },
+        "blake2b-wasm": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-1.1.7.tgz",
+            "integrity": "sha512-oFIHvXhlz/DUgF0kq5B1CqxIDjIJwh9iDeUUGQUcvgiGz7Wdw03McEO7CfLBy7QKGdsydcMCgO9jFNBAFCtFcA==",
+            "requires": {
+                "nanoassert": "1.1.0"
+            }
+        },
         "block-stream": {
             "version": "0.0.9",
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.3"
             }
         },
         "bluebird": {
@@ -220,7 +236,7 @@
             "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "requires": {
-                "hoek": "2.x.x"
+                "hoek": "2.16.3"
             }
         },
         "brace-expansion": {
@@ -228,7 +244,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -238,7 +254,7 @@
             "integrity": "sha1-y0gQe/RGcn0+F7IRAtpzyokQlYg=",
             "requires": {
                 "bigi": "0.2.0",
-                "binstring": "~0.2.0"
+                "binstring": "0.2.1"
             },
             "dependencies": {
                 "bigi": {
@@ -253,9 +269,9 @@
             "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
             "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
             "requires": {
-                "bs58": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "safe-buffer": "^5.1.2"
+                "bs58": "4.0.1",
+                "create-hash": "1.2.0",
+                "safe-buffer": "5.1.2"
             },
             "dependencies": {
                 "bs58": {
@@ -263,7 +279,7 @@
                     "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
                     "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
                     "requires": {
-                        "base-x": "^3.0.2"
+                        "base-x": "3.0.4"
                     }
                 }
             }
@@ -307,8 +323,8 @@
             "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "co": {
@@ -326,9 +342,9 @@
             "resolved": "https://registry.npmjs.org/coinkey/-/coinkey-0.1.0.tgz",
             "integrity": "sha1-vfKpU9z+T9cP26MADHh/82nYKUw=",
             "requires": {
-                "coinstring": "~0.2.0",
-                "eckey": "~0.4.0",
-                "secure-random": "~0.2.0"
+                "coinstring": "0.2.0",
+                "eckey": "0.4.2",
+                "secure-random": "0.2.1"
             },
             "dependencies": {
                 "secure-random": {
@@ -343,8 +359,8 @@
             "resolved": "https://registry.npmjs.org/coinstring/-/coinstring-0.2.0.tgz",
             "integrity": "sha1-+iggSXu541t8+hFvBIIZym8/NI8=",
             "requires": {
-                "bs58": "0.3.x",
-                "crypto-hashing": "~0.3.0"
+                "bs58": "0.3.0",
+                "crypto-hashing": "0.3.1"
             }
         },
         "combined-stream": {
@@ -352,7 +368,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
             }
         },
         "commander": {
@@ -370,8 +386,8 @@
             "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
             "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
             "requires": {
-                "ini": "^1.3.4",
-                "proto-list": "~1.2.1"
+                "ini": "1.3.5",
+                "proto-list": "1.2.4"
             }
         },
         "console-control-strings": {
@@ -399,11 +415,11 @@
             "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "requires": {
-                "cipher-base": "^1.0.1",
-                "inherits": "^2.0.1",
-                "md5.js": "^1.3.4",
-                "ripemd160": "^2.0.1",
-                "sha.js": "^2.4.0"
+                "cipher-base": "1.0.4",
+                "inherits": "2.0.3",
+                "md5.js": "1.3.4",
+                "ripemd160": "2.0.2",
+                "sha.js": "2.4.11"
             },
             "dependencies": {
                 "ripemd160": {
@@ -411,8 +427,8 @@
                     "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
                     "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
                     "requires": {
-                        "hash-base": "^3.0.0",
-                        "inherits": "^2.0.1"
+                        "hash-base": "3.0.4",
+                        "inherits": "2.0.3"
                     }
                 }
             }
@@ -422,12 +438,12 @@
             "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "requires": {
-                "cipher-base": "^1.0.3",
-                "create-hash": "^1.1.0",
-                "inherits": "^2.0.1",
-                "ripemd160": "^2.0.0",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "cipher-base": "1.0.4",
+                "create-hash": "1.2.0",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.2",
+                "sha.js": "2.4.11"
             },
             "dependencies": {
                 "ripemd160": {
@@ -435,8 +451,8 @@
                     "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
                     "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
                     "requires": {
-                        "hash-base": "^3.0.0",
-                        "inherits": "^2.0.1"
+                        "hash-base": "3.0.4",
+                        "inherits": "2.0.3"
                     }
                 }
             }
@@ -451,7 +467,7 @@
             "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "requires": {
-                "boom": "2.x.x"
+                "boom": "2.10.1"
             }
         },
         "crypto-hashing": {
@@ -459,8 +475,8 @@
             "resolved": "https://registry.npmjs.org/crypto-hashing/-/crypto-hashing-0.3.1.tgz",
             "integrity": "sha1-AZVUjbi971CqnVJlFMxUbh5i+84=",
             "requires": {
-                "binstring": "0.2.x",
-                "ripemd160": "~0.2.0"
+                "binstring": "0.2.1",
+                "ripemd160": "0.2.1"
             }
         },
         "dashdash": {
@@ -468,7 +484,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -512,7 +528,7 @@
             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
             "optional": true,
             "requires": {
-                "jsbn": "~0.1.0"
+                "jsbn": "0.1.1"
             }
         },
         "ecdsa": {
@@ -520,8 +536,8 @@
             "resolved": "https://registry.npmjs.org/ecdsa/-/ecdsa-0.6.0.tgz",
             "integrity": "sha1-NemIe29Bjse5g4AXAzTcJ2Omsxc=",
             "requires": {
-                "bigi": "^1.2.1",
-                "ecurve": "^1.0.0"
+                "bigi": "1.4.2",
+                "ecurve": "1.0.6"
             }
         },
         "eckey": {
@@ -529,9 +545,9 @@
             "resolved": "https://registry.npmjs.org/eckey/-/eckey-0.4.2.tgz",
             "integrity": "sha1-zqU7fVKeQhaPLIWXp+jTK8njlDY=",
             "requires": {
-                "bigi": "0.2.x",
-                "ecurve": "~0.3.0",
-                "ecurve-names": "~0.3.0"
+                "bigi": "0.2.0",
+                "ecurve": "0.3.2",
+                "ecurve-names": "0.3.0"
             },
             "dependencies": {
                 "bigi": {
@@ -544,7 +560,7 @@
                     "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-0.3.2.tgz",
                     "integrity": "sha1-ut7/nvlTme6i4X0bUz8BBIQkC1A=",
                     "requires": {
-                        "bigi": "0.2.x"
+                        "bigi": "0.2.0"
                     }
                 }
             }
@@ -554,8 +570,8 @@
             "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.6.tgz",
             "integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==",
             "requires": {
-                "bigi": "^1.1.0",
-                "safe-buffer": "^5.0.1"
+                "bigi": "1.4.2",
+                "safe-buffer": "5.1.2"
             }
         },
         "ecurve-names": {
@@ -563,8 +579,8 @@
             "resolved": "https://registry.npmjs.org/ecurve-names/-/ecurve-names-0.3.0.tgz",
             "integrity": "sha1-+VJeQD9Eo197wXVX/35BCRkx1Zw=",
             "requires": {
-                "bigi": "0.2.x",
-                "ecurve": "~0.3.0"
+                "bigi": "0.2.0",
+                "ecurve": "0.3.2"
             },
             "dependencies": {
                 "bigi": {
@@ -577,7 +593,7 @@
                     "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-0.3.2.tgz",
                     "integrity": "sha1-ut7/nvlTme6i4X0bUz8BBIQkC1A=",
                     "requires": {
-                        "bigi": "0.2.x"
+                        "bigi": "0.2.0"
                     }
                 }
             }
@@ -587,11 +603,11 @@
             "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
             "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
             "requires": {
-                "bluebird": "^3.0.5",
-                "commander": "^2.9.0",
-                "lru-cache": "^3.2.0",
-                "semver": "^5.1.0",
-                "sigmund": "^1.0.1"
+                "bluebird": "3.5.1",
+                "commander": "2.16.0",
+                "lru-cache": "3.2.0",
+                "semver": "5.5.0",
+                "sigmund": "1.0.1"
             }
         },
         "end-of-stream": {
@@ -604,12 +620,11 @@
         },
         "equihashverify": {
             "version": "git+https://github.com/z-nomp/equihashverify.git#ba1709c4bb8460fae364c9e25d3bba1c1bf229c6",
-            "from": "git+https://github.com/z-nomp/equihashverify.git",
             "requires": {
-                "bindings": "*",
-                "libsodium": "^0.7.3",
-                "nan": "*",
-                "node-gyp": "*"
+                "bindings": "1.3.0",
+                "libsodium": "0.7.3",
+                "nan": "2.10.0",
+                "node-gyp": "3.7.0"
             }
         },
         "expand-template": {
@@ -637,9 +652,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
             "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.5",
-                "mime-types": "^2.1.12"
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.6",
+                "mime-types": "2.1.19"
             }
         },
         "fs-constants": {
@@ -657,10 +672,10 @@
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
             }
         },
         "gauge": {
@@ -683,7 +698,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -703,12 +718,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "graceful-fs": {
@@ -726,8 +741,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
             "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
             "requires": {
-                "ajv": "^4.9.1",
-                "har-schema": "^1.0.5"
+                "ajv": "4.11.8",
+                "har-schema": "1.0.5"
             }
         },
         "has-unicode": {
@@ -740,8 +755,8 @@
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
             "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "hawk": {
@@ -749,10 +764,10 @@
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "requires": {
-                "boom": "2.x.x",
-                "cryptiles": "2.x.x",
-                "hoek": "2.x.x",
-                "sntp": "1.x.x"
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
             }
         },
         "hoek": {
@@ -765,9 +780,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
             "requires": {
-                "assert-plus": "^0.2.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.14.2"
             }
         },
         "inflight": {
@@ -775,8 +790,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -822,10 +837,10 @@
             "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.7.5.tgz",
             "integrity": "sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==",
             "requires": {
-                "config-chain": "~1.1.5",
-                "editorconfig": "^0.13.2",
-                "mkdirp": "~0.5.0",
-                "nopt": "~3.0.1"
+                "config-chain": "1.1.11",
+                "editorconfig": "0.13.3",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6"
             }
         },
         "jsbn": {
@@ -844,7 +859,7 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "requires": {
-                "jsonify": "~0.0.0"
+                "jsonify": "0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -890,7 +905,7 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
             "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
             "requires": {
-                "pseudomap": "^1.0.1"
+                "pseudomap": "1.0.2"
             }
         },
         "md5.js": {
@@ -898,8 +913,8 @@
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
             "requires": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1"
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3"
             }
         },
         "merkle-bitcoin": {
@@ -907,7 +922,7 @@
             "resolved": "https://registry.npmjs.org/merkle-bitcoin/-/merkle-bitcoin-1.0.2.tgz",
             "integrity": "sha1-CAp3LRCQP+oWAoegz6sHk2ARS44=",
             "requires": {
-                "async": "^1.2.1"
+                "async": "1.5.2"
             },
             "dependencies": {
                 "async": {
@@ -932,7 +947,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
             "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
             "requires": {
-                "mime-db": "~1.35.0"
+                "mime-db": "1.35.0"
             }
         },
         "mimic-response": {
@@ -945,7 +960,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
             }
         },
         "minimist": {
@@ -973,6 +988,11 @@
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
             "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
         },
+        "nanoassert": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+            "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
+        },
         "node-abi": {
             "version": "2.4.3",
             "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
@@ -986,18 +1006,18 @@
             "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.7.0.tgz",
             "integrity": "sha512-qDQE/Ft9xXP6zphwx4sD0t+VhwV7yFaloMpfbL2QnnDZcyaiakWlLdtFGGQfTAwpFHdpbRhRxVhIHN1OKAjgbg==",
             "requires": {
-                "fstream": "^1.0.0",
-                "glob": "^7.0.3",
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "^0.5.0",
-                "nopt": "2 || 3",
-                "npmlog": "0 || 1 || 2 || 3 || 4",
-                "osenv": "0",
-                "request": ">=2.9.0 <2.82.0",
-                "rimraf": "2",
-                "semver": "~5.3.0",
-                "tar": "^2.0.0",
-                "which": "1"
+                "fstream": "1.0.11",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6",
+                "npmlog": "4.1.2",
+                "osenv": "0.1.5",
+                "request": "2.81.0",
+                "rimraf": "2.6.2",
+                "semver": "5.3.0",
+                "tar": "2.2.1",
+                "which": "1.3.1"
             },
             "dependencies": {
                 "semver": {
@@ -1017,7 +1037,7 @@
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
             "requires": {
-                "abbrev": "1"
+                "abbrev": "1.1.1"
             }
         },
         "npmlog": {
@@ -1069,8 +1089,8 @@
             "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
             "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
             }
         },
         "path-is-absolute": {
@@ -1115,7 +1135,7 @@
             "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
             "integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
             "requires": {
-                "asap": "~2.0.3"
+                "asap": "2.0.6"
             }
         },
         "proto-list": {
@@ -1147,7 +1167,7 @@
             "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
             "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
             "requires": {
-                "bitcoin-ops": "^1.3.0"
+                "bitcoin-ops": "1.4.1"
             }
         },
         "qs": {
@@ -1160,7 +1180,7 @@
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
             "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
             "requires": {
-                "safe-buffer": "^5.1.0"
+                "safe-buffer": "5.1.2"
             }
         },
         "rc": {
@@ -1193,28 +1213,28 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
             "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
             "requires": {
-                "aws-sign2": "~0.6.0",
-                "aws4": "^1.2.1",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.0",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.1.1",
-                "har-validator": "~4.2.1",
-                "hawk": "~3.1.3",
-                "http-signature": "~1.1.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.7",
-                "oauth-sign": "~0.8.1",
-                "performance-now": "^0.2.0",
-                "qs": "~6.4.0",
-                "safe-buffer": "^5.0.1",
-                "stringstream": "~0.0.4",
-                "tough-cookie": "~2.3.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.0.0"
+                "aws-sign2": "0.6.0",
+                "aws4": "1.7.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.6",
+                "extend": "3.0.2",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.19",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.1.2",
+                "stringstream": "0.0.6",
+                "tough-cookie": "2.3.4",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.3.2"
             }
         },
         "rimraf": {
@@ -1222,7 +1242,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.2"
             }
         },
         "ripemd160": {
@@ -1260,8 +1280,8 @@
             "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "sha1": {
@@ -1269,8 +1289,8 @@
             "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
             "integrity": "sha1-rdqnqTFo85PxnrKxUJFhjicA+Eg=",
             "requires": {
-                "charenc": ">= 0.0.1",
-                "crypt": ">= 0.0.1"
+                "charenc": "0.0.2",
+                "crypt": "0.0.2"
             }
         },
         "sha256": {
@@ -1278,8 +1298,8 @@
             "resolved": "https://registry.npmjs.org/sha256/-/sha256-0.1.1.tgz",
             "integrity": "sha1-NClvkEmNo+jGsG//6Ohg26KZ+QI=",
             "requires": {
-                "convert-hex": "~0.1.0",
-                "convert-string": "~0.1.0"
+                "convert-hex": "0.1.0",
+                "convert-string": "0.1.0"
             }
         },
         "sigmund": {
@@ -1312,7 +1332,7 @@
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "requires": {
-                "hoek": "2.x.x"
+                "hoek": "2.16.3"
             }
         },
         "sshpk": {
@@ -1320,15 +1340,15 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
             "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.2",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2",
+                "tweetnacl": "0.14.5"
             },
             "dependencies": {
                 "assert-plus": {
@@ -1379,9 +1399,9 @@
             "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
             }
         },
         "tar-fs": {
@@ -1430,7 +1450,7 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "requires": {
-                "punycode": "^1.4.1"
+                "punycode": "1.4.1"
             }
         },
         "tunnel-agent": {
@@ -1467,7 +1487,7 @@
             "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
             "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
             "requires": {
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "verror": {
@@ -1475,9 +1495,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "^1.0.0",
+                "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
+                "extsprintf": "1.3.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -1492,7 +1512,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
             }
         },
         "which-pm-runs": {
@@ -1513,7 +1533,7 @@
             "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
             "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
             "requires": {
-                "bs58check": "<3.0.0"
+                "bs58check": "2.1.2"
             }
         },
         "wrappy": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "async": "^2.6.1",
         "base58-native": "^0.1.4",
         "bignum": "^0.13.0",
-        "bitcoinjs-lib-zcash": "^3.4.2",
+        "bitcoinjs-lib-zcash": "git+https://github.com/z-nomp/bitcoinjs-lib.git",
         "equihashverify": "git+https://github.com/z-nomp/equihashverify.git",
         "merkle-bitcoin": "^1.0.2",
         "promise": "^8.0.1"


### PR DESCRIPTION
A commit was merged upstream that caused all coins that don't have
support for overwinter to break. This is a problem so we've forked the
repo and are maintaining our own copy to ensure we don't merge updates
that break functionality.