### PR TITLE
Add request dependency to resolve security issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "ajv": {
-            "version": "4.11.8",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-            "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
                 "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
+                "fast-deep-equal": "1.1.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
             }
         },
         "ansi-regex": {
@@ -48,9 +50,9 @@
             "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
         },
         "assert-plus": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
         "async": {
             "version": "2.6.1",
@@ -66,9 +68,9 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "aws-sign2": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
             "version": "1.7.0",
@@ -79,14 +81,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-        },
-        "base-x": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
-            "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
-            "requires": {
-                "safe-buffer": "5.1.2"
-            }
         },
         "base58-native": {
             "version": "0.1.4",
@@ -105,21 +99,6 @@
                 "tweetnacl": "0.14.5"
             }
         },
-        "bech32": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.3.tgz",
-            "integrity": "sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg=="
-        },
-        "big-integer": {
-            "version": "1.6.32",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.32.tgz",
-            "integrity": "sha512-ljKJdR3wk9thHfLj4DtrNiOSTxvGFaMjWrG4pW75juXC4j7+XuKJVFdg4kgFMYp85PVkO05dFMj2dk2xVsH4xw=="
-        },
-        "bigi": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
-            "integrity": "sha1-nGZalfiLiwj8Bc/XMfVhhZ1yWCU="
-        },
         "bignum": {
             "version": "0.13.0",
             "resolved": "https://registry.npmjs.org/bignum/-/bignum-0.13.0.tgz",
@@ -136,62 +115,6 @@
             "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
             "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
         },
-        "binstring": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/binstring/-/binstring-0.2.1.tgz",
-            "integrity": "sha1-ihdNMB9tVO/aVQ3Zi7TLUk6s110="
-        },
-        "bip66": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-            "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-            "requires": {
-                "safe-buffer": "5.1.2"
-            }
-        },
-        "bitcoin-ops": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
-            "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
-        },
-        "bitcoin-script": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/bitcoin-script/-/bitcoin-script-0.1.1.tgz",
-            "integrity": "sha1-UsUE3dweOxMXp7ZWeoiYGz7zkpw=",
-            "requires": {
-                "big-integer": "1.6.32",
-                "bigi": "1.4.2",
-                "coinkey": "0.1.0",
-                "ecdsa": "0.6.0",
-                "js-beautify": "1.7.5",
-                "ripemd160": "0.2.1",
-                "secure-random": "1.1.1",
-                "sha1": "1.1.1",
-                "sha256": "0.1.1"
-            }
-        },
-        "bitcoinjs-lib-zcash": {
-            "version": "git+https://github.com/z-nomp/bitcoinjs-lib.git#fc523458e9ace8465e8d95ce621b360c44c8f6db",
-            "requires": {
-                "bech32": "1.1.3",
-                "bigi": "1.4.2",
-                "bip66": "1.1.5",
-                "bitcoin-ops": "1.4.1",
-                "bitcoin-script": "0.1.1",
-                "blake2b": "2.1.2",
-                "bs58check": "2.1.2",
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "ecurve": "1.0.6",
-                "merkle-lib": "2.0.10",
-                "pushdata-bitcoin": "1.0.1",
-                "randombytes": "2.0.6",
-                "safe-buffer": "5.1.2",
-                "typeforce": "1.12.0",
-                "varuint-bitcoin": "1.1.0",
-                "wif": "2.0.6"
-            }
-        },
         "bl": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -201,23 +124,6 @@
                 "safe-buffer": "5.1.2"
             }
         },
-        "blake2b": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.2.tgz",
-            "integrity": "sha1-aIDt3KNc/t6SxPsnJCITNPmJFFo=",
-            "requires": {
-                "blake2b-wasm": "1.1.7",
-                "nanoassert": "1.1.0"
-            }
-        },
-        "blake2b-wasm": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-1.1.7.tgz",
-            "integrity": "sha512-oFIHvXhlz/DUgF0kq5B1CqxIDjIJwh9iDeUUGQUcvgiGz7Wdw03McEO7CfLBy7QKGdsydcMCgO9jFNBAFCtFcA==",
-            "requires": {
-                "nanoassert": "1.1.0"
-            }
-        },
         "block-stream": {
             "version": "0.0.9",
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -225,11 +131,6 @@
             "requires": {
                 "inherits": "2.0.3"
             }
-        },
-        "bluebird": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-            "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
         },
         "boom": {
             "version": "2.10.1",
@@ -246,42 +147,6 @@
             "requires": {
                 "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
-            }
-        },
-        "bs58": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/bs58/-/bs58-0.3.0.tgz",
-            "integrity": "sha1-y0gQe/RGcn0+F7IRAtpzyokQlYg=",
-            "requires": {
-                "bigi": "0.2.0",
-                "binstring": "0.2.1"
-            },
-            "dependencies": {
-                "bigi": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/bigi/-/bigi-0.2.0.tgz",
-                    "integrity": "sha1-i+4mNIuZxK4u0gSB+xI4TDJ5L3Q="
-                }
-            }
-        },
-        "bs58check": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-            "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-            "requires": {
-                "bs58": "4.0.1",
-                "create-hash": "1.2.0",
-                "safe-buffer": "5.1.2"
-            },
-            "dependencies": {
-                "bs58": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-                    "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-                    "requires": {
-                        "base-x": "3.0.4"
-                    }
-                }
             }
         },
         "buffer-alloc": {
@@ -308,24 +173,10 @@
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
-        "charenc": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-            "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
-        },
         "chownr": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
             "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
-        },
-        "cipher-base": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-            "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
-            }
         },
         "co": {
             "version": "4.6.0",
@@ -337,32 +188,6 @@
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
-        "coinkey": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/coinkey/-/coinkey-0.1.0.tgz",
-            "integrity": "sha1-vfKpU9z+T9cP26MADHh/82nYKUw=",
-            "requires": {
-                "coinstring": "0.2.0",
-                "eckey": "0.4.2",
-                "secure-random": "0.2.1"
-            },
-            "dependencies": {
-                "secure-random": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/secure-random/-/secure-random-0.2.1.tgz",
-                    "integrity": "sha1-HC8Iy5TYwG3v9SchpgRbupb4Wpo="
-                }
-            }
-        },
-        "coinstring": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/coinstring/-/coinstring-0.2.0.tgz",
-            "integrity": "sha1-+iggSXu541t8+hFvBIIZym8/NI8=",
-            "requires": {
-                "bs58": "0.3.0",
-                "crypto-hashing": "0.3.1"
-            }
-        },
         "combined-stream": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
@@ -371,96 +196,20 @@
                 "delayed-stream": "1.0.0"
             }
         },
-        "commander": {
-            "version": "2.16.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
-            "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew=="
-        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "config-chain": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
-            "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
-            "requires": {
-                "ini": "1.3.5",
-                "proto-list": "1.2.4"
-            }
         },
         "console-control-strings": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
-        "convert-hex": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/convert-hex/-/convert-hex-0.1.0.tgz",
-            "integrity": "sha1-CMBFaJIsJ3drii6BqV05M2LqC2U="
-        },
-        "convert-string": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/convert-string/-/convert-string-0.1.0.tgz",
-            "integrity": "sha1-ec5BqbsNA7z3LNxqjzxW+7xkQQo="
-        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "create-hash": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-            "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-            "requires": {
-                "cipher-base": "1.0.4",
-                "inherits": "2.0.3",
-                "md5.js": "1.3.4",
-                "ripemd160": "2.0.2",
-                "sha.js": "2.4.11"
-            },
-            "dependencies": {
-                "ripemd160": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-                    "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-                    "requires": {
-                        "hash-base": "3.0.4",
-                        "inherits": "2.0.3"
-                    }
-                }
-            }
-        },
-        "create-hmac": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-            "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-            "requires": {
-                "cipher-base": "1.0.4",
-                "create-hash": "1.2.0",
-                "inherits": "2.0.3",
-                "ripemd160": "2.0.2",
-                "safe-buffer": "5.1.2",
-                "sha.js": "2.4.11"
-            },
-            "dependencies": {
-                "ripemd160": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-                    "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-                    "requires": {
-                        "hash-base": "3.0.4",
-                        "inherits": "2.0.3"
-                    }
-                }
-            }
-        },
-        "crypt": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-            "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
         },
         "cryptiles": {
             "version": "2.0.5",
@@ -470,28 +219,12 @@
                 "boom": "2.10.1"
             }
         },
-        "crypto-hashing": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/crypto-hashing/-/crypto-hashing-0.3.1.tgz",
-            "integrity": "sha1-AZVUjbi971CqnVJlFMxUbh5i+84=",
-            "requires": {
-                "binstring": "0.2.1",
-                "ripemd160": "0.2.1"
-            }
-        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
                 "assert-plus": "1.0.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
             }
         },
         "decompress-response": {
@@ -523,91 +256,13 @@
             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
         },
         "ecc-jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
-            }
-        },
-        "ecdsa": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/ecdsa/-/ecdsa-0.6.0.tgz",
-            "integrity": "sha1-NemIe29Bjse5g4AXAzTcJ2Omsxc=",
-            "requires": {
-                "bigi": "1.4.2",
-                "ecurve": "1.0.6"
-            }
-        },
-        "eckey": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/eckey/-/eckey-0.4.2.tgz",
-            "integrity": "sha1-zqU7fVKeQhaPLIWXp+jTK8njlDY=",
-            "requires": {
-                "bigi": "0.2.0",
-                "ecurve": "0.3.2",
-                "ecurve-names": "0.3.0"
-            },
-            "dependencies": {
-                "bigi": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/bigi/-/bigi-0.2.0.tgz",
-                    "integrity": "sha1-i+4mNIuZxK4u0gSB+xI4TDJ5L3Q="
-                },
-                "ecurve": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-0.3.2.tgz",
-                    "integrity": "sha1-ut7/nvlTme6i4X0bUz8BBIQkC1A=",
-                    "requires": {
-                        "bigi": "0.2.0"
-                    }
-                }
-            }
-        },
-        "ecurve": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.6.tgz",
-            "integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==",
-            "requires": {
-                "bigi": "1.4.2",
-                "safe-buffer": "5.1.2"
-            }
-        },
-        "ecurve-names": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/ecurve-names/-/ecurve-names-0.3.0.tgz",
-            "integrity": "sha1-+VJeQD9Eo197wXVX/35BCRkx1Zw=",
-            "requires": {
-                "bigi": "0.2.0",
-                "ecurve": "0.3.2"
-            },
-            "dependencies": {
-                "bigi": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/bigi/-/bigi-0.2.0.tgz",
-                    "integrity": "sha1-i+4mNIuZxK4u0gSB+xI4TDJ5L3Q="
-                },
-                "ecurve": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-0.3.2.tgz",
-                    "integrity": "sha1-ut7/nvlTme6i4X0bUz8BBIQkC1A=",
-                    "requires": {
-                        "bigi": "0.2.0"
-                    }
-                }
-            }
-        },
-        "editorconfig": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
-            "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
-            "requires": {
-                "bluebird": "3.5.1",
-                "commander": "2.16.0",
-                "lru-cache": "3.2.0",
-                "semver": "5.5.0",
-                "sigmund": "1.0.1"
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2"
             }
         },
         "end-of-stream": {
@@ -642,15 +297,25 @@
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
+        "fast-deep-equal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+        },
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
             "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "form-data": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-            "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "requires": {
                 "asynckit": "0.4.0",
                 "combined-stream": "1.0.6",
@@ -699,13 +364,6 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
                 "assert-plus": "1.0.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
             }
         },
         "github-from-package": {
@@ -732,32 +390,23 @@
             "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "har-schema": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-            "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-            "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
             }
         },
         "has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
             "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-        },
-        "hash-base": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-            "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-            "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
-            }
         },
         "hawk": {
             "version": "3.1.3",
@@ -776,11 +425,11 @@
             "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
         },
         "http-signature": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "0.2.0",
+                "assert-plus": "1.0.0",
                 "jsprim": "1.4.1",
                 "sshpk": "1.14.2"
             }
@@ -832,17 +481,6 @@
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
-        "js-beautify": {
-            "version": "1.7.5",
-            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.7.5.tgz",
-            "integrity": "sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==",
-            "requires": {
-                "config-chain": "1.1.11",
-                "editorconfig": "0.13.3",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6"
-            }
-        },
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -853,6 +491,11 @@
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
             "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        },
+        "json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
         },
         "json-stable-stringify": {
             "version": "1.0.1",
@@ -881,13 +524,6 @@
                 "extsprintf": "1.3.0",
                 "json-schema": "0.2.3",
                 "verror": "1.10.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
             }
         },
         "libsodium": {
@@ -899,23 +535,6 @@
             "version": "4.17.10",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
             "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-        },
-        "lru-cache": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
-            "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
-            "requires": {
-                "pseudomap": "1.0.2"
-            }
-        },
-        "md5.js": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
-            "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
-            "requires": {
-                "hash-base": "3.0.4",
-                "inherits": "2.0.3"
-            }
         },
         "merkle-bitcoin": {
             "version": "1.0.2",
@@ -931,11 +550,6 @@
                     "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
                 }
             }
-        },
-        "merkle-lib": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/merkle-lib/-/merkle-lib-2.0.10.tgz",
-            "integrity": "sha1-grjbrnXieneFOItz+ddyXQ9vMyY="
         },
         "mime-db": {
             "version": "1.35.0",
@@ -988,11 +602,6 @@
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
             "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
         },
-        "nanoassert": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
-            "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
-        },
         "node-abi": {
             "version": "2.4.3",
             "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
@@ -1020,6 +629,98 @@
                 "which": "1.3.1"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "4.11.8",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                    "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+                    "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                    }
+                },
+                "assert-plus": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                    "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+                },
+                "aws-sign2": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                    "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+                },
+                "form-data": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                    "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.6",
+                        "mime-types": "2.1.19"
+                    }
+                },
+                "har-schema": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+                    "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+                },
+                "har-validator": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                    "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+                    "requires": {
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
+                    }
+                },
+                "http-signature": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                    "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+                    "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.1",
+                        "sshpk": "1.14.2"
+                    }
+                },
+                "performance-now": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+                    "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+                },
+                "qs": {
+                    "version": "6.4.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+                    "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+                },
+                "request": {
+                    "version": "2.81.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+                    "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.7.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.6",
+                        "extend": "3.0.2",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "4.2.1",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.19",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "0.2.0",
+                        "qs": "6.4.0",
+                        "safe-buffer": "5.1.2",
+                        "stringstream": "0.0.6",
+                        "tough-cookie": "2.3.4",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.3.2"
+                    }
+                },
                 "semver": {
                     "version": "5.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -1099,9 +800,9 @@
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "performance-now": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-            "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "prebuild-install": {
             "version": "4.0.0",
@@ -1138,16 +839,6 @@
                 "asap": "2.0.6"
             }
         },
-        "proto-list": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-            "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
-        },
-        "pseudomap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-        },
         "pump": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
@@ -1162,26 +853,10 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
-        "pushdata-bitcoin": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
-            "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
-            "requires": {
-                "bitcoin-ops": "1.4.1"
-            }
-        },
         "qs": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-            "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-        },
-        "randombytes": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-            "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
-            "requires": {
-                "safe-buffer": "5.1.2"
-            }
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "rc": {
             "version": "1.2.8",
@@ -1209,29 +884,27 @@
             }
         },
         "request": {
-            "version": "2.81.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-            "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+            "version": "2.87.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+            "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
             "requires": {
-                "aws-sign2": "0.6.0",
+                "aws-sign2": "0.7.0",
                 "aws4": "1.7.0",
                 "caseless": "0.12.0",
                 "combined-stream": "1.0.6",
                 "extend": "3.0.2",
                 "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
+                "form-data": "2.3.2",
+                "har-validator": "5.0.3",
+                "http-signature": "1.2.0",
                 "is-typedarray": "1.0.0",
                 "isstream": "0.1.2",
                 "json-stringify-safe": "5.0.1",
                 "mime-types": "2.1.19",
                 "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
+                "performance-now": "2.1.0",
+                "qs": "6.5.2",
                 "safe-buffer": "5.1.2",
-                "stringstream": "0.0.6",
                 "tough-cookie": "2.3.4",
                 "tunnel-agent": "0.6.0",
                 "uuid": "3.3.2"
@@ -1245,11 +918,6 @@
                 "glob": "7.1.2"
             }
         },
-        "ripemd160": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.1.tgz",
-            "integrity": "sha1-3uGSSKPhyBX/muo551OjN/VqJD0="
-        },
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -1260,11 +928,6 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
-        "secure-random": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/secure-random/-/secure-random-1.1.1.tgz",
-            "integrity": "sha1-CIDy2MUYX0vLRoQFjINrTdsHFFo="
-        },
         "semver": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -1274,38 +937,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-        },
-        "sha.js": {
-            "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-            "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
-            }
-        },
-        "sha1": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
-            "integrity": "sha1-rdqnqTFo85PxnrKxUJFhjicA+Eg=",
-            "requires": {
-                "charenc": "0.0.2",
-                "crypt": "0.0.2"
-            }
-        },
-        "sha256": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/sha256/-/sha256-0.1.1.tgz",
-            "integrity": "sha1-NClvkEmNo+jGsG//6Ohg26KZ+QI=",
-            "requires": {
-                "convert-hex": "0.1.0",
-                "convert-string": "0.1.0"
-            }
-        },
-        "sigmund": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
         },
         "signal-exit": {
             "version": "3.0.2",
@@ -1344,18 +975,11 @@
                 "assert-plus": "1.0.0",
                 "bcrypt-pbkdf": "1.0.2",
                 "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
+                "ecc-jsbn": "0.1.2",
                 "getpass": "0.1.7",
                 "jsbn": "0.1.1",
                 "safer-buffer": "2.1.2",
                 "tweetnacl": "0.14.5"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
             }
         },
         "string-width": {
@@ -1467,11 +1091,6 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "optional": true
         },
-        "typeforce": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.12.0.tgz",
-            "integrity": "sha512-fvnkvueAOFLhtAqDgIA/wMP21SMwS/NQESFKZuwVrj5m/Ew6eK2S0z0iB++cwtROPWDOhaT6OUfla8UwMw4Adg=="
-        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1482,14 +1101,6 @@
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
             "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         },
-        "varuint-bitcoin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
-            "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
-            "requires": {
-                "safe-buffer": "5.1.2"
-            }
-        },
         "verror": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -1498,13 +1109,6 @@
                 "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
                 "extsprintf": "1.3.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
             }
         },
         "which": {
@@ -1526,14 +1130,6 @@
             "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
             "requires": {
                 "string-width": "1.0.2"
-            }
-        },
-        "wif": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-            "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
-            "requires": {
-                "bs58check": "2.1.2"
             }
         },
         "wrappy": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,10 @@
         "bitcoinjs-lib-zcash": "git+https://github.com/z-nomp/bitcoinjs-lib.git",
         "equihashverify": "git+https://github.com/z-nomp/equihashverify.git",
         "merkle-bitcoin": "^1.0.2",
-        "promise": "^8.0.1"
+        "promise": "^8.0.1",
+        "request": "^2.87"
     },
+    "_note": "request is only included here to force an update from the version required by node-gyp which is required by equihashverify. There is a vulnerability in hapijs/hoek 2.16.3 which is pulled from node-gyp@3",
     "engines": {
         "node": ">=8.11"
     }


### PR DESCRIPTION
node-gyp@3 is pulling in an older version of request which is pulling in
(through other dependencies) hapijs/hoek version 2.16.3 which has a
security vulnerability. This commit requires a newer version of request
which forces npm to select a more recent version of hoek.